### PR TITLE
feat: Implement player theater mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -116,3 +116,14 @@ body {
 body > iframe{
   display: none;
 }
+
+body.theater-mode-active::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.8); /* Dimming overlay */
+  z-index: 999; /* Below player (which will be 1000), above everything else */
+}


### PR DESCRIPTION
This commit introduces a theater mode feature to the video player, similar to the functionality found on platforms like YouTube.

Key changes include:

- Added a new state variable `inTheaterMode` to the `Player` component.
- Introduced a theater mode toggle button to the player controls with icons `fas fa-desktop` (enter) and `far fa-window-minimize` (exit).
- Implemented dynamic styling for `PlayerDiv` using styled-components:
    - In theater mode, the player expands to 100vw width and 80vh height, positioned fixed at the top-left with a black background.
- Added a global CSS class `theater-mode-active` to the body when theater mode is on, which creates a dimming overlay for other page content.
- Handled interactions between theater mode and fullscreen mode:
    - If theater mode is active, it's temporarily disabled when entering fullscreen and restored upon exiting fullscreen.
    - The theater mode button is non-interactive while in fullscreen.
    - Double-clicking the player to enter/exit fullscreen also respects and restores theater mode if it was active.

The implementation ensures that player controls (play/pause, volume, PiP) and mouse hover behavior for showing/hiding controls remain functional in theater mode.